### PR TITLE
225 index author names (#226)

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Collection.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Collection.java
@@ -43,7 +43,7 @@ public class Collection extends Common {
     private List<String> publicationVenueFor;
 
     @NestedObject
-    @Indexed(type = "nested_whole_strings", searchable = false)
+    @Indexed(type = "nested_tokenized_strings", copyTo = "_text_")
     @PropertySource(template = "collection/author", predicate = "http://www.w3.org/2000/01/rdf-schema#label")
     private List<String> authors;
 

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
@@ -48,7 +48,7 @@ public class Document extends Common {
     @PropertySource(template = "document/hasPublicationVenueFor", predicate = "http://www.w3.org/2000/01/rdf-schema#label", unique = true)
     private String hasPublicationVenueFor;
 
-    @Indexed(type = "nested_whole_strings")
+    @Indexed(type = "nested_tokenized_strings", copyTo = "_text_")
     @NestedObject(properties = { @Reference(value = "authorOrganization", key = "organizations") })
     @PropertySource(template = "document/author", predicate = "http://www.w3.org/2000/01/rdf-schema#label")
     private List<String> authors;


### PR DESCRIPTION
* 225: Tokenize author field for documents

Allow searching by author name

* 225: Move to nested tokenized string for authors

Need to use nested_tokenized_string since authors is a nested object

Also update authors field annotation on Collection since it is the same
field in the index