### PR TITLE
Run harvest/index in serial

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/service/IndexService.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/service/IndexService.java
@@ -65,11 +65,11 @@ public class IndexService {
             triplestore.init();
             Instant start = Instant.now();
             logger.info("Indexing...");
-            harvesters.parallelStream().forEach(harvester -> {
+            harvesters.stream().forEach(harvester -> {
                 logger.info(String.format("Indexing %s documents.", harvester.type().getSimpleName()));
                 if (indexers.stream().anyMatch(indexer -> indexer.type().equals(harvester.type()))) {
                     harvester.harvest().buffer(indexBatchSize).subscribe(batch -> {
-                        indexers.parallelStream().filter(indexer -> indexer.type().equals(harvester.type())).forEach(indexer -> {
+                        indexers.stream().filter(indexer -> indexer.type().equals(harvester.type())).forEach(indexer -> {
                             indexer.index(batch);
                         });
                     });


### PR DESCRIPTION
The parallelization approach indexes incorrectly on small datasets. The managed_schema becomes mangled when Spring Solr is attempting to update the schema on index concurrently.